### PR TITLE
[cpio] Update to 2.15. Fixes JB#62491

### DIFF
--- a/rpm/cpio-2.10-longnames-split.patch
+++ b/rpm/cpio-2.10-longnames-split.patch
@@ -6,10 +6,10 @@ Subject: [PATCH 6/7] Fix for splitting long file names while creating ustar
 Resolves: #866467
 
 diff --git a/src/tar.c b/src/tar.c
-index a2ce171..e2b5f45 100644
+index 318cbbe..c93d573 100644
 --- a/src/tar.c
 +++ b/src/tar.c
-@@ -49,10 +49,12 @@ split_long_name (const char *name, size_t length)
+@@ -48,10 +48,12 @@ split_long_name (const char *name, size_t length)
  {
    size_t i;
  

--- a/rpm/cpio-2.11-crc-fips-nit.patch
+++ b/rpm/cpio-2.11-crc-fips-nit.patch
@@ -5,7 +5,7 @@ Subject: [PATCH 7/7] Note that cpio uses Sum32 checksum only
 Related to Package Wrangler and FIPS check.
 
 diff --git a/src/main.c b/src/main.c
-index a875a13..13cdfcf 100644
+index 4ef695e..6effd6c 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -167,7 +167,7 @@ static struct argp_option options[] = {

--- a/rpm/cpio-2.14-dev_number.patch
+++ b/rpm/cpio-2.14-dev_number.patch
@@ -3,10 +3,10 @@ Date: Mon, 14 Sep 2015 09:37:15 +0200
 Subject: [PATCH 3/7] Support major/minor device numbers over 127 (bz#450109)
 
 diff --git a/src/copyin.c b/src/copyin.c
-index 2e72356..5d88a23 100644
+index ace0a02..1ac843f 100644
 --- a/src/copyin.c
 +++ b/src/copyin.c
-@@ -1287,15 +1287,15 @@ read_in_binary (struct cpio_file_stat *file_hdr,
+@@ -1303,15 +1303,15 @@ read_in_binary (struct cpio_file_stat *file_hdr,
        swab_array ((char *) short_hdr, 13);
      }
  

--- a/rpm/cpio-2.14-exitCode.patch
+++ b/rpm/cpio-2.14-exitCode.patch
@@ -2,7 +2,7 @@ Subject: [PATCH 2/7] set exit code to 1 when cpio fails to store file > 4GB
  (#183224)
 
 diff --git a/src/copyout.c b/src/copyout.c
-index fa999bd..6e82f4c 100644
+index 582e696..08f0e9e 100644
 --- a/src/copyout.c
 +++ b/src/copyout.c
 @@ -287,7 +287,7 @@ field_width_error (const char *filename, const char *fieldname,
@@ -15,7 +15,7 @@ index fa999bd..6e82f4c 100644
  	 STRINGIFY_BIGINT (value, valbuf),
  	 STRINGIFY_BIGINT (MAX_VAL_WITH_DIGITS (width - nul, LG_8),
 diff --git a/tests/CVE-2019-14866.at b/tests/CVE-2019-14866.at
-index 530365a..5a4e15c 100644
+index 3e2b8ca..cbddfee 100644
 --- a/tests/CVE-2019-14866.at
 +++ b/tests/CVE-2019-14866.at
 @@ -30,6 +30,5 @@ fi
@@ -25,4 +25,3 @@ index 530365a..5a4e15c 100644
 -2 blocks
  ])
  AT_CLEANUP
-

--- a/rpm/cpio-2.14-patternnamesigsegv.patch
+++ b/rpm/cpio-2.14-patternnamesigsegv.patch
@@ -4,10 +4,10 @@ Subject: [PATCH 5/7] fix segfault with nonexisting file with patternnames
  (#567022)
 
 diff --git a/src/copyin.c b/src/copyin.c
-index 5d88a23..f2babb7 100644
+index 1ac843f..ea89e30 100644
 --- a/src/copyin.c
 +++ b/src/copyin.c
-@@ -948,21 +948,24 @@ read_pattern_file (void)
+@@ -964,21 +964,24 @@ read_pattern_file (void)
  
    pattern_fp = fopen (pattern_file_name, "r");
    if (pattern_fp == NULL)

--- a/rpm/cpio-2.14-rh.patch
+++ b/rpm/cpio-2.14-rh.patch
@@ -3,7 +3,7 @@ Date: Mon, 14 Sep 2015 09:27:21 +0200
 Subject: [PATCH 1/7] make '-c' equivalent to '-H newc'
 
 diff --git a/doc/cpio.texi b/doc/cpio.texi
-index edf0c12..bef7ba5 100644
+index 6683806..1d06d46 100644
 --- a/doc/cpio.texi
 +++ b/doc/cpio.texi
 @@ -271,7 +271,8 @@ Sets the I/O block size to @var{block-size} * 512 bytes.
@@ -47,7 +47,7 @@ index edf0c12..bef7ba5 100644
  @item -C @var{io-size}
  @itemx --io-size=@var{io-size}
 diff --git a/src/main.c b/src/main.c
-index b27bd17..542a71f 100644
+index d2135c8..4ef695e 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -124,7 +124,7 @@ static struct argp_option options[] = {

--- a/rpm/cpio-2.9.90-defaultremoteshell.patch
+++ b/rpm/cpio-2.9.90-defaultremoteshell.patch
@@ -4,7 +4,7 @@ Subject: [PATCH 4/7] define default remote shell as /usr/bin/ssh(#452904), use
  /etc/rmt as default rmt command
 
 diff --git a/paxutils/lib/rtapelib.c b/paxutils/lib/rtapelib.c
-index 7213031..7d0bd52 100644
+index 82522b9..af8e794 100644
 --- a/paxutils/lib/rtapelib.c
 +++ b/paxutils/lib/rtapelib.c
 @@ -59,6 +59,10 @@
@@ -17,4 +17,3 @@ index 7213031..7d0bd52 100644
 +
  #include <rmt.h>
  #include <rmt-command.h>
- 

--- a/rpm/cpio.spec
+++ b/rpm/cpio.spec
@@ -1,6 +1,6 @@
 Name:       cpio
 Summary:    A GNU archiving program
-Version:    2.14
+Version:    2.15
 Release:    1
 License:    GPLv3+
 URL:        http://www.gnu.org/software/cpio/
@@ -91,13 +91,11 @@ install -m0644 -t %{buildroot}%{_docdir}/%{name}-%{version} \
         AUTHORS ChangeLog NEWS README THANKS
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %{_bindir}/*
 /bin/cpio
 
 %files doc
-%defattr(-,root,root,-)
 %{_infodir}/%{name}.*
 %{_mandir}/man1/%{name}.*
 %{_docdir}/%{name}-%{version}


### PR DESCRIPTION
Update cpio to 2.15 and regenerate the patches.

I wasn't able to apply every patch in Platform SDK since `cpio-2.9.90-defaultremoteshell.patch` tries to patch a submodule of a submodule (`upstream/paxutils`), but applying it manually and skipping the patch let me continue.

I assume the cpio submodule updated its submodules accordingly, but please double check that.