### PR TITLE
Use gnu17 standard to fix build gcc 15

### DIFF
--- a/rpm/cpio.spec
+++ b/rpm/cpio.spec
@@ -73,6 +73,7 @@ Man pages for %{name}.
     --gnulib-srcdir=gnulib \
     --skip-po
 
+export CFLAGS="$RPM_OPT_FLAGS -std=gnu17"
 %configure \
     --disable-nls
 


### PR DESCRIPTION
With gcc 15 and newer C23 is the default standard which breaks the build.